### PR TITLE
Added random matchmaking functionality

### DIFF
--- a/src/socket/route.ts
+++ b/src/socket/route.ts
@@ -54,6 +54,7 @@ io.use(function(socket, next) {
 
 	// cancel searching for opponent
 	socket.on("cancel", (code) => {
+		console.log(`${socket.decoded.user} has canceled their search`)
 		tracker.cancelSearch(code);
 		socket.emit("cancelled");
 	});

--- a/src/socket/route.ts
+++ b/src/socket/route.ts
@@ -32,7 +32,8 @@ io.use(function(socket, next) {
 
 	// search for random opponent
 	socket.on("search", async (difficulty) => {
-		if(difficulty != "Any" && difficulty != "Easy" && difficulty != "Medium" && difficulty != "Hard") {
+		console.log(`${socket.decoded.user} is searching for an opponent with '${difficulty}' difficulty`)
+		if(difficulty !== "Any" && difficulty !== "Easy" && difficulty !== "Medium" && difficulty !== "Hard") {
 			socket.emit("error", "invalid difficulty");
 			return;
 		}
@@ -42,8 +43,10 @@ io.use(function(socket, next) {
 		let found = res[1]
 		socket.join(code);
 		if(!found) {
+			console.log("no opponent found")
 			socket.emit("searching", code);
 		} else {
+			console.log("opponent found")
 			io.to(code).emit("match", code);
 			await startRace(code, socket);
 		}
@@ -57,7 +60,7 @@ io.use(function(socket, next) {
 
 	// create new private lobby
 	socket.on("create", (difficulty) => {
-		if(difficulty == "Any" || difficulty == "Easy" || difficulty == "Medium" || difficulty == "Hard") {
+		if(difficulty === "Any" || difficulty === "Easy" || difficulty === "Medium" || difficulty === "Hard") {
 			let code = tracker.createLobby(difficulty);
 			socket.join(code);
 			socket.emit("create", code);	

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     // "removeComments": true,                /* Do not emit comments to output. */
     // "noEmit": true,                        /* Do not emit outputs. */
     // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
     /* Strict Type-Checking Options */
     "strict": true, /* Enable all strict type-checking options. */


### PR DESCRIPTION
Fixes #5 

Added random matchmaking functionality. Includes two new event listeners: "search" and "cancel". 

Search takes the difficulty as a parameter and emits "searching" back to the client with a room key if no match can immediately be made. As soon a second user enter a search for the same difficulty, a "match" event will be emitting to both users with a socket room key that is later needed for the problem submit event. Then, the race will start automatically and emit a "start" event with the Leetcode problem.

Cancel takes a room key and tells the tracker to cancel the search corresponding to this room key.

Also, I should note that I removed the "/race/private" socket.io namespace. Both private and public lobbies will both connect through the same namespace.